### PR TITLE
RABSW-914 Host-mount lustre tools and libs into CSI driver.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,7 @@
-FROM ghcr.io/nearnodeflash/rhel-ubi8-lustre:latest AS base
-
-WORKDIR /
-
-# Install basic dependencies
-RUN microdnf install -y make git gzip wget gcc tar
-
-WORKDIR /
-
-ENV GO_VERSION=1.17.6
-RUN wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && tar -xzf go${GO_VERSION}.linux-amd64.tar.gz
-
-#
-# Note: The COPY commands below have the potential to invalidate any layer
-# that follows.
-#
-
-FROM base as builder
+FROM golang:1.17 as builder
 
 # Set Go environment
-ENV GOROOT="/go"
-ENV PATH="${PATH}:${GOROOT}/bin" GOPRIVATE="github.hpe.com"
+ENV GOPRIVATE="github.hpe.com"
 
 WORKDIR /workspace
 
@@ -38,20 +20,20 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o nnf-csi-driver main.go
 
 ENTRYPOINT ["/bin/sh"]
 
-FROM builder as testing
-WORKDIR /workspace
-
-COPY Makefile .
-
-RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
-    make manifests && make generate && make fmt &&  make vet && \
-    mkdir -p /workspace/testbin && /bin/bash -c "test -f /workspace/testbin/setup-envtest.sh || curl -sSLo /workspace/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh" && \
-    /bin/bash -c "source /workspace/testbin/setup-envtest.sh; fetch_envtest_tools /workspace/testbin; setup_envtest_env /workspace/testbin"
-
-ENTRYPOINT ["sh", "/workspace/initiateContainerTest.sh"]
+#FROM builder as testing
+#WORKDIR /workspace
+#
+#COPY Makefile .
+#
+#RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
+#    make manifests && make generate && make fmt &&  make vet && \
+#    mkdir -p /workspace/testbin && /bin/bash -c "test -f /workspace/testbin/setup-envtest.sh || curl -sSLo /workspace/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh" && \
+#    /bin/bash -c "source /workspace/testbin/setup-envtest.sh; fetch_envtest_tools /workspace/testbin; setup_envtest_env /workspace/testbin"
+#
+#ENTRYPOINT ["bash", "/workspace/initiateContainerTest.sh"]
 
 # The final application stage.
-FROM base
+FROM redhat/ubi8-minimal
 
 WORKDIR /
 # Retrieve executable from previous layer

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,6 @@ run: fmt vet
 
 docker-build: Dockerfile fmt vet
 	# Name the base stages so they are not lost during a cache prune.
-	time ${DOCKER} build -t ${IMG}-base --target base .
-	time ${DOCKER} build -t ${IMG}-app-base --target application-base .
 	time ${DOCKER} build -t ${IMG} .
 
 kind-push:

--- a/config/lustre/kustomization.yaml
+++ b/config/lustre/kustomization.yaml
@@ -7,3 +7,7 @@ patches:
     version: v1
     kind: DaemonSet
     name: lustre-csi-node
+
+patchesStrategicMerge:
+# Let the node-manager daemonset mount host dirs for lustre tools and libs.
+- manager_volumes_patch.yaml

--- a/config/lustre/manager_volumes_patch.yaml
+++ b/config/lustre/manager_volumes_patch.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lustre-csi-node
+spec:
+  template:
+    spec:
+      containers:
+      - name: csi-node-driver
+        volumeMounts:
+          - mountPath: /mnt
+            name: mnt-dir
+            mountPropagation: Bidirectional
+          - mountPath: /dev
+            name: dev-dir
+            mountPropagation: HostToContainer
+          - mountPath: /usr/bin
+            name: ubin-dir
+          - mountPath: /usr/sbin
+            name: usbin-dir
+          - mountPath: /usr/lib
+            name: ulib-dir
+          - mountPath: /usr/lib64
+            name: lib64-dir
+      volumes:
+        - name: mnt-dir
+          hostPath:
+            path: /mnt
+        - name: dev-dir
+          hostPath:
+            path: /dev
+        - name: ubin-dir
+          hostPath:
+            path: /usr/bin
+        - name: usbin-dir
+          hostPath:
+            path: /usr/sbin
+        - name: ulib-dir
+          hostPath:
+            path: /usr/lib
+        - name: lib64-dir
+          hostPath:
+            path: /usr/lib64


### PR DESCRIPTION
Host-mount the lustre tools and libs, making the container smaller and allowing
it to not care about kernel updates on the host.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>