### PR TITLE
RABSW-915: LustreCSI: Adjust the module name to match the repo name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hewlettpackard/lustre-csi-driver
+module github.com/HewlettPackard/lustre-csi-driver
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/rexray/gocsi"
 
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/driver"
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/lustre-driver"
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/mock-driver"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/driver"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/mock-driver"
 )
 
 // main is ignored when this package is built as a go plug-in.

--- a/pkg/lustre-driver/lustre.go
+++ b/pkg/lustre-driver/lustre.go
@@ -22,9 +22,9 @@ package lustre
 import (
 	"github.com/rexray/gocsi"
 
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/driver"
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/lustre-driver/provider"
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/lustre-driver/service"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/driver"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver/provider"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver/service"
 )
 
 func NewLustreDriver() driver.DriverApi {

--- a/pkg/lustre-driver/provider/provider.go
+++ b/pkg/lustre-driver/provider/provider.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rexray/gocsi"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/lustre-driver/service"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver/service"
 )
 
 // New returns a new CSI Storage Plug-in Provider.

--- a/pkg/mock-driver/mock.go
+++ b/pkg/mock-driver/mock.go
@@ -22,9 +22,9 @@ package mock
 import (
 	"github.com/rexray/gocsi"
 
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/driver"
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/mock-driver/provider"
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/mock-driver/service"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/driver"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/mock-driver/provider"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/mock-driver/service"
 )
 
 func NewMockDriver() driver.DriverApi {

--- a/pkg/mock-driver/provider/provider.go
+++ b/pkg/mock-driver/provider/provider.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rexray/gocsi"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/hewlettpackard/lustre-csi-driver/pkg/mock-driver/service"
+	"github.com/HewlettPackard/lustre-csi-driver/pkg/mock-driver/service"
 )
 
 // New returns a new CSI Storage Plug-in Provider.


### PR DESCRIPTION
hewlettpackard -> HewlettPackard