### PR TITLE
Add Rabbit overlay.

### DIFF
--- a/config/rabbit/kustomization.yaml
+++ b/config/rabbit/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../lustre
+
+patchesStrategicMerge:
+- manager_tolerations_patch.yaml

--- a/config/rabbit/manager_tolerations_patch.yaml
+++ b/config/rabbit/manager_tolerations_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lustre-csi-node
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cray.nnf.node: "true"
+      tolerations:
+      - key: "cray.nnf.node"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"


### PR DESCRIPTION
This builds on Caleb's PR that sanitizes rabbit stuff from lustre-csi-driver: https://github.com/HewlettPackard/lustre-csi-driver/pull/10

This puts the rabbit overlay in the lustre-csi-driver repo, as a quick first step.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>