### PR TITLE
Minor Refactoring/Renaming and Comment Improvements

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,9 +24,10 @@ import (
 )
 
 type DriverApi interface {
-	// The name of the driver
+
+	// Name is the name of the driver
 	Name() string
 
-	// The storage provider allocator method of the driver
+	// Provider is the storage provider allocator method of the driver
 	Provider() func() gocsi.StoragePluginProvider
 }

--- a/pkg/lustre-driver/lustre.go
+++ b/pkg/lustre-driver/lustre.go
@@ -28,10 +28,10 @@ import (
 )
 
 func NewLustreDriver() driver.DriverApi {
-	return &lustreDriver{}
+	return &LustreDriver{}
 }
 
-type lustreDriver struct{}
+type LustreDriver struct{}
 
-func (lustreDriver) Name() string                                 { return service.Name }
-func (lustreDriver) Provider() func() gocsi.StoragePluginProvider { return provider.New }
+func (LustreDriver) Name() string                                 { return service.Name }
+func (LustreDriver) Provider() func() gocsi.StoragePluginProvider { return provider.New }

--- a/pkg/lustre-driver/service/controller.go
+++ b/pkg/lustre-driver/service/controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-func (s *service) CreateVolume(
+func (s *LustreService) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, error) {
@@ -33,7 +33,7 @@ func (s *service) CreateVolume(
 	return nil, nil
 }
 
-func (s *service) DeleteVolume(
+func (s *LustreService) DeleteVolume(
 	ctx context.Context,
 	req *csi.DeleteVolumeRequest) (
 	*csi.DeleteVolumeResponse, error) {
@@ -41,7 +41,7 @@ func (s *service) DeleteVolume(
 	return nil, nil
 }
 
-func (s *service) ControllerPublishVolume(
+func (s *LustreService) ControllerPublishVolume(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest) (
 	*csi.ControllerPublishVolumeResponse, error) {
@@ -49,7 +49,7 @@ func (s *service) ControllerPublishVolume(
 	return nil, nil
 }
 
-func (s *service) ControllerUnpublishVolume(
+func (s *LustreService) ControllerUnpublishVolume(
 	ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest) (
 	*csi.ControllerUnpublishVolumeResponse, error) {
@@ -57,7 +57,7 @@ func (s *service) ControllerUnpublishVolume(
 	return nil, nil
 }
 
-func (s *service) ValidateVolumeCapabilities(
+func (s *LustreService) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest) (
 	*csi.ValidateVolumeCapabilitiesResponse, error) {
@@ -65,7 +65,7 @@ func (s *service) ValidateVolumeCapabilities(
 	return nil, nil
 }
 
-func (s *service) ListVolumes(
+func (s *LustreService) ListVolumes(
 	ctx context.Context,
 	req *csi.ListVolumesRequest) (
 	*csi.ListVolumesResponse, error) {
@@ -73,14 +73,14 @@ func (s *service) ListVolumes(
 	return nil, nil
 }
 
-func (s *service) ControllerGetVolume(
+func (s *LustreService) ControllerGetVolume(
 	ctx context.Context,
 	req *csi.ControllerGetVolumeRequest) (
 	*csi.ControllerGetVolumeResponse, error) {
 	return nil, nil
 }
 
-func (s *service) GetCapacity(
+func (s *LustreService) GetCapacity(
 	ctx context.Context,
 	req *csi.GetCapacityRequest) (
 	*csi.GetCapacityResponse, error) {
@@ -88,7 +88,7 @@ func (s *service) GetCapacity(
 	return nil, nil
 }
 
-func (s *service) ControllerGetCapabilities(
+func (s *LustreService) ControllerGetCapabilities(
 	ctx context.Context,
 	req *csi.ControllerGetCapabilitiesRequest) (
 	*csi.ControllerGetCapabilitiesResponse, error) {
@@ -96,7 +96,7 @@ func (s *service) ControllerGetCapabilities(
 	return nil, nil
 }
 
-func (s *service) CreateSnapshot(
+func (s *LustreService) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest) (
 	*csi.CreateSnapshotResponse, error) {
@@ -104,7 +104,7 @@ func (s *service) CreateSnapshot(
 	return nil, nil
 }
 
-func (s *service) DeleteSnapshot(
+func (s *LustreService) DeleteSnapshot(
 	ctx context.Context,
 	req *csi.DeleteSnapshotRequest) (
 	*csi.DeleteSnapshotResponse, error) {
@@ -112,7 +112,7 @@ func (s *service) DeleteSnapshot(
 	return nil, nil
 }
 
-func (s *service) ListSnapshots(
+func (s *LustreService) ListSnapshots(
 	ctx context.Context,
 	req *csi.ListSnapshotsRequest) (
 	*csi.ListSnapshotsResponse, error) {
@@ -120,7 +120,7 @@ func (s *service) ListSnapshots(
 	return nil, nil
 }
 
-func (s *service) ControllerExpandVolume(
+func (s *LustreService) ControllerExpandVolume(
 	ctx context.Context,
 	req *csi.ControllerExpandVolumeRequest) (
 	*csi.ControllerExpandVolumeResponse, error) {

--- a/pkg/lustre-driver/service/identity.go
+++ b/pkg/lustre-driver/service/identity.go
@@ -25,7 +25,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-func (s *service) GetPluginInfo(
+func (s *LustreService) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (
 	*csi.GetPluginInfoResponse, error) {
@@ -36,7 +36,7 @@ func (s *service) GetPluginInfo(
 	}, nil
 }
 
-func (s *service) GetPluginCapabilities(
+func (s *LustreService) GetPluginCapabilities(
 	ctx context.Context,
 	req *csi.GetPluginCapabilitiesRequest) (
 	*csi.GetPluginCapabilitiesResponse, error) {
@@ -44,7 +44,7 @@ func (s *service) GetPluginCapabilities(
 	return &csi.GetPluginCapabilitiesResponse{}, nil
 }
 
-func (s *service) Probe(
+func (s *LustreService) Probe(
 	ctx context.Context,
 	req *csi.ProbeRequest) (
 	*csi.ProbeResponse, error) {

--- a/pkg/lustre-driver/service/service.go
+++ b/pkg/lustre-driver/service/service.go
@@ -31,16 +31,21 @@ const (
 	VendorVersion = "v0.0.1"
 )
 
-// Service is a CSI SP and idempotency.Provider.
+// Service is a CSI SP and idempotency.Provider
+// Contains 3 interface fields, each of which have a set of functions that must be implemented.
 type Service interface {
 	csi.ControllerServer
 	csi.IdentityServer
 	csi.NodeServer
 }
 
-type service struct{}
+// LustreService implements the Service interface.
+// All the inner interfaces' functions (ControllerServer, IdentityServer, and NodeServer)
+// are implemented as methods.
+type LustreService struct {
+}
 
 // New returns a new Service.
 func New() Service {
-	return &service{}
+	return &LustreService{}
 }

--- a/pkg/mock-driver/mock.go
+++ b/pkg/mock-driver/mock.go
@@ -28,10 +28,10 @@ import (
 )
 
 func NewMockDriver() driver.DriverApi {
-	return &mockDriver{}
+	return &MockDriver{}
 }
 
-type mockDriver struct{}
+type MockDriver struct{}
 
-func (mockDriver) Name() string                                 { return service.Name }
-func (mockDriver) Provider() func() gocsi.StoragePluginProvider { return provider.New }
+func (MockDriver) Name() string                                 { return service.Name }
+func (MockDriver) Provider() func() gocsi.StoragePluginProvider { return provider.New }


### PR DESCRIPTION
## Notes

Minor refactoring of struct type names per Go standards, removal of ghost comments/TODOs, add Go doc function comment.

## Commits

* Clean up node.go comments
* Refactor naming of interfaces and structs
* Refactor naming of interfaces and structs in mock/