### PR TITLE
RABSW-974 Let the lustre-csi-driver deployment default to lustre-capa…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 #   export KUBECONFIG=/my/kubeconfig.file
 #   make deploy OVERLAY=lustre
 #
-OVERLAY ?= default
+OVERLAY ?= lustre
 
 all: build
 

--- a/config/kind/kustomization.yaml
+++ b/config/kind/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - ../default


### PR DESCRIPTION
…ble.

Change the default kustomize overlay to be "lustre". Add a separate overlay for
"kind".

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>