### PR TITLE
Add /bin and /sbin volumeMounts to csi-node-driver

### DIFF
--- a/config/lustre/manager_volumes_patch.yaml
+++ b/config/lustre/manager_volumes_patch.yaml
@@ -22,6 +22,10 @@ spec:
             name: ulib-dir
           - mountPath: /usr/lib64
             name: lib64-dir
+          - mountPath: /bin
+            name: bin-dir
+          - mountPath: /sbin
+            name: sbin-dir
       volumes:
         - name: mnt-dir
           hostPath:
@@ -41,3 +45,9 @@ spec:
         - name: lib64-dir
           hostPath:
             path: /usr/lib64
+        - name: bin-dir
+          hostPath:
+            path: /bin
+        - name: sbin-dir
+          hostPath:
+            path: /sbin


### PR DESCRIPTION
This adds the `/bin` and `/sbin` volumeMounts to the csi-node-driver container.
We noticed a problem when running this docker container on top of an OpenSUSE host OS, where the `mount.lustre` binary resides in `/sbin` and needs to be present in the container when `mount -t lustre ...` is executed. Other binaries, like `bash`, live in the host OS' `/bin` directory, which is *not* a symlink to /usr/bin like it is on RHEL.