### PR TITLE
Update registry and image name

### DIFF
--- a/charts/lustre-csi-driver/templates/plugin.yaml
+++ b/charts/lustre-csi-driver/templates/plugin.yaml
@@ -76,7 +76,7 @@ spec:
         # node-driver-registrar registers your CSI driver with Kubelet so that it knows which Unix
         # domain socket to issue the CSI calls on.
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: lustre-csi-system
 resources:
-  - namespace.yaml
-  - driver.yaml
-  - plugin.yaml
+- namespace.yaml
+- driver.yaml
+- plugin.yaml
 images:
-  - name: controller
-  - newName: ghcr.io/hewlettpackard/lustre-csi-driver
-  - newTag: 5fa68458cbcd53aa0b61749b4f7f8cd99401b814
+- name: controller
+  newName: ghcr.io/hewlettpackard/lustre-csi-driver
+  newTag: latest

--- a/deploy/kubernetes/base/plugin.yaml
+++ b/deploy/kubernetes/base/plugin.yaml
@@ -75,7 +75,7 @@ spec:
         # node-driver-registrar registers your CSI driver with Kubelet so that it knows which Unix
         # domain socket to issue the CSI calls on.
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/lustre-csi-driver-kind.yaml
+++ b/deploy/kubernetes/lustre-csi-driver-kind.yaml
@@ -43,7 +43,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: controller:latest
+        image: ghcr.io/hewlettpackard/lustre-csi-driver:latest
         imagePullPolicy: Always
         name: csi-node-driver
         securityContext:
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
         name: csi-node-driver-registrar
         securityContext:
           privileged: true

--- a/deploy/kubernetes/lustre-csi-driver.yaml
+++ b/deploy/kubernetes/lustre-csi-driver.yaml
@@ -43,7 +43,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: controller:latest
+        image: ghcr.io/hewlettpackard/lustre-csi-driver:latest
         imagePullPolicy: Always
         name: csi-node-driver
         securityContext:
@@ -75,7 +75,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
         name: csi-node-driver-registrar
         securityContext:
           privileged: true


### PR DESCRIPTION
Uses GHCR image name instead of controller:latest and updates which registry is used for kubernetes images:
In May it was announced that people should move to [registry.k8s.io](http://registry.k8s.io/) - https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)