### PR TITLE
Fix example PV/PVC for example usage docs

### DIFF
--- a/deploy/kubernetes/base/example_pv.yaml
+++ b/deploy/kubernetes/base/example_pv.yaml
@@ -7,14 +7,14 @@ spec:
     storage: 1Gi
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: lustre-fs
   persistentVolumeReclaimPolicy: Retain
   # Reserve this PV for the matching PVC.
   claimRef:
     kind: PersistentVolumeClaim
     name: pvc-example
-    namespace: lustre-csi-system
+    namespace: default
   # Represent the volume as managed by an external CSI volume driver
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#csipersistentvolumesource-v1-core
   csi:

--- a/deploy/kubernetes/base/example_pvc.yaml
+++ b/deploy/kubernetes/base/example_pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pvc-example
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   # storageClassName for the PVC must match the corresponding PV's spec.storageClassName
   storageClassName: lustre-fs
   # volumeName for the PVC must match the corresponding PV's metadata.name


### PR DESCRIPTION
## Description

This fixes the example PV/PVC config files to be in line with the usage description docs.
Closes #23

## Commits

* Change ReadWriteOnce access mode to ReadWriteMany
* Change claimRef namespace to default, what example PVC uses

Signed-off-by: Caleb Carlson <ccarlson355@gmail.com>