### PR TITLE
Remove imagePullPolicy of Always

### DIFF
--- a/charts/lustre-csi-driver/templates/plugin.yaml
+++ b/charts/lustre-csi-driver/templates/plugin.yaml
@@ -43,7 +43,6 @@ spec:
             # This is necessary only for systems with SELinux, where the CSI driver needs
             # to mount the mount-dir with bidirectional mount propagation.
             privileged: true
-          imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/deploy/kubernetes/base/plugin.yaml
+++ b/deploy/kubernetes/base/plugin.yaml
@@ -42,7 +42,6 @@ spec:
             # This is necessary only for systems with SELinux, where the CSI driver needs
             # to mount the mount-dir with bidirectional mount propagation.
             privileged: true
-          imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/deploy/kubernetes/lustre-csi-driver-kind.yaml
+++ b/deploy/kubernetes/lustre-csi-driver-kind.yaml
@@ -44,7 +44,6 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         image: ghcr.io/hewlettpackard/lustre-csi-driver:latest
-        imagePullPolicy: Always
         name: csi-node-driver
         securityContext:
           privileged: true

--- a/deploy/kubernetes/lustre-csi-driver.yaml
+++ b/deploy/kubernetes/lustre-csi-driver.yaml
@@ -44,7 +44,6 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         image: ghcr.io/hewlettpackard/lustre-csi-driver:latest
-        imagePullPolicy: Always
         name: csi-node-driver
         securityContext:
           privileged: true


### PR DESCRIPTION
## Description

This removes the `imagePullPolicy` field that was set to static `Always`. This lets the Kubernetes environment, along with the image tag, determine whether or not to pull the image.

- This removes the field from the Helm chart template plugin.yaml. 
- `make installer` was used to regenerate the lustre-csi-driver.yaml and lustre-csi-driver-kind.yaml files once the field was removed from the base plugin.yaml.

Note: This PR closes #28