### PR TITLE
Disable length check to permit long path names

### DIFF
--- a/charts/lustre-csi-driver/templates/plugin.yaml
+++ b/charts/lustre-csi-driver/templates/plugin.yaml
@@ -49,6 +49,8 @@ spec:
               value: unix:///csi/csi.sock
             - name: X_CSI_DEBUG
               value: "true"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/kubernetes/base/plugin.yaml
+++ b/deploy/kubernetes/base/plugin.yaml
@@ -48,6 +48,8 @@ spec:
               value: unix:///csi/csi.sock
             - name: X_CSI_DEBUG
               value: "true"
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/kubernetes/lustre-csi-driver-kind.yaml
+++ b/deploy/kubernetes/lustre-csi-driver-kind.yaml
@@ -38,6 +38,8 @@ spec:
           value: unix:///csi/csi.sock
         - name: X_CSI_DEBUG
           value: "true"
+        - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+          value: "true"
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:

--- a/deploy/kubernetes/lustre-csi-driver.yaml
+++ b/deploy/kubernetes/lustre-csi-driver.yaml
@@ -38,6 +38,8 @@ spec:
           value: unix:///csi/csi.sock
         - name: X_CSI_DEBUG
           value: "true"
+        - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+          value: "true"
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
The current limitation is 128 characters. 

Anything greater would report an error
`"/csi.v1.Node/NodePublishVolume: REP 0254: rpc error: code = InvalidArgument desc = exceeds size limit: TargetPath: max=128, size=132"`

NNF, in particular nnf-dm, could create a path exceeding that limit quite easily

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>