### PR TITLE
Fixups for the release workflow tools.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - 'master'
+      - 'releases/v*'
     tags:
       - 'v*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - 'master'
+      - 'releases/v*'
 
 env:
   # TEST_TARGET: Name of the testing target in the Dockerfile
@@ -36,11 +39,10 @@ jobs:
       id: lowercase-repository-name
       run: echo "REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-    - name: set tags for main/master
+    - name: "Set tags for main/master"
       id: set_tags
       run: |
-        echo "VERSION_TAG=$(./git-version-gen)" >> ${GITHUB_ENV}
-        echo "LATEST_TAG=latest" >> ${GITHUB_ENV}
+        echo "VERSION_TAG=$(./git-version-gen | grep -v UNKNOWN)" >> ${GITHUB_ENV}
         echo "TEST_TAG=$(git rev-parse HEAD)-test" >> ${GITHUB_ENV}
         echo "SHA_TAG=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
         echo "${GITHUB_ENV}:"
@@ -54,16 +56,19 @@ jobs:
         images: |
           ghcr.io/${{ env.REPO_NAME }}
         tags: |
-          # for merge to master branch, tag example: 'master'
+          # For merge to master branch, tag example: 'master'
           type=ref,event=branch
-          # for PR event, tag example: 'pr-3'
+          # For PR event, tag example: 'pr-3'
           type=ref,event=pr
-          # for PR event or merge event, tag example: 0.0.1.12-5667
+          # For PR event or merge event, tag example: 1.0.1.12-5667
           type=raw,value=${{ env.VERSION_TAG }}
-          # for PR event or merge, tag example: 566769e04d2436cf5f42ae4f46092c7dff6e668e
+          # For PR event or merge, tag example: 566769e04d2436cf5f42ae4f46092c7dff6e668e
           type=raw,value=${{ env.SHA_TAG }}          
-          # for push to semver tag, tag example: 0.0.2
+          # For push to semver tag, tag example: 1.0.2
+          # This also sets 'latest'.
           type=semver,pattern={{version}}
+          # For push to semver tag, tag example: 1.0
+          type=semver,pattern={{major}}.{{minor}}
 
     - name: "Docker login"
       id: docker_login
@@ -82,14 +87,15 @@ jobs:
         target: ${{ env.TEST_TARGET }}
         tags: ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
 
-    - name: Run the Docker image unit tests
+    - name: "Run the Docker image unit tests"
       id: docker_test
       if: ${{ env.DO_TEST == 'true' }}
       run: docker run ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
 
-    - name: Build the final Docker image
+    - name: "Build the final Docker image"
       id: docker_build
       uses: docker/build-push-action@v3
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
+

--- a/.github/workflows/verify_tag.yaml
+++ b/.github/workflows/verify_tag.yaml
@@ -1,9 +1,7 @@
-# Release workflow: Pushing a tag triggers this workflow,
-# which uses the name of the tag as the container tag/version
-# that goes into GHCR.
-name: Release
+# Pushing a tag triggers this workflow, which verifies that it is an
+# annotated tag.
+name: Verify tag
 
-# Build and publish Docker image upon pushing a tag
 on:
   push:
     tags:
@@ -16,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        # actions/checkout@v2 breaks annotated tags by converting them into
+      - uses: actions/checkout@v3
+        # actions/checkout@v3 breaks annotated tags by converting them into
         # lightweight tags, so we need to force fetch the tag again
         # See: https://github.com/actions/checkout/issues/290
       - name: "Repair tag"

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,14 @@ installer-gen: kustomize edit-image
 installer: ## Generates full .yaml output from Kustomize for base and overlays
 	make installer-gen OVERLAY=base && make installer-gen OVERLAY=overlays/kind OVERLAY_LABEL=-kind
 
+# Let .version be phony so that a git update to the workarea can be reflected
+# in it each time it's needed.
+.PHONY: .version
 .version: ## Uses the git-version-gen script to generate a tag version
-	./git-version-gen > .version
+	./git-version-gen --fallback `git rev-parse HEAD` > .version
 
 clean:
-	rm .version
+	rm -f .version
 
 
 ## Location to install dependencies to

--- a/git-version-gen
+++ b/git-version-gen
@@ -166,7 +166,7 @@ then
     # Remove the "g" to save a byte.
     v=`echo "$v" | sed 's/-\([^-]*\)-g\([^-]*\)$/.\1-\2/'`;
     v_from_git=1
-elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
+elif test "x$fallback" = x; then
     v=UNKNOWN
 else
     v=$fallback


### PR DESCRIPTION
On the master branch, allow git-version-gen to use the SHA as the value for the .version file, because there are no tags on the master branch for it to use for that purpose.  This allows nnf-deploy to succeed when using this master branch in a KIND environment.

Rename the workflow that verifies tags.

Build and do tags on "releases/v*" branches.

Weed out the "UNKNOWN" from git-version-gen.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>