### PR TITLE
Don't return an error from NodeUnpublishVolume when the target path d…

### DIFF
--- a/pkg/lustre-driver/service/node.go
+++ b/pkg/lustre-driver/service/node.go
@@ -20,6 +20,8 @@
 package service
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -105,7 +107,7 @@ func (s *service) NodeUnpublishVolume(
 
 	mounter := mount.New("")
 	notMountPoint, err := mount.IsNotMountPoint(mounter, req.GetTargetPath())
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume - Mount point check Failed: Error %v", err)
 	} else if !notMountPoint {
 		err := mounter.Unmount(req.GetTargetPath())

--- a/pkg/lustre-driver/service/node.go
+++ b/pkg/lustre-driver/service/node.go
@@ -107,8 +107,10 @@ func (s *service) NodeUnpublishVolume(
 
 	mounter := mount.New("")
 	notMountPoint, err := mount.IsNotMountPoint(mounter, req.GetTargetPath())
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume - Mount point check Failed: Error %v", err)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume - Mount point check Failed: Error %v", err)
+		}
 	} else if !notMountPoint {
 		err := mounter.Unmount(req.GetTargetPath())
 


### PR DESCRIPTION
Don't return an error from NodeUnpublishVolume when the target path does not exist. This ensures the process succeeds when the target path is not present.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>