### PR TITLE
Update versions of base images in deployment

### DIFF
--- a/charts/lustre-csi-driver/templates/plugin.yaml
+++ b/charts/lustre-csi-driver/templates/plugin.yaml
@@ -29,7 +29,7 @@ spec:
         # already in use (listen unix /csi/csi.sock: bind: address already in use). To combat this, we
         # cleanup the socket, if present, on container init.
         - name: init-socket
-          image: busybox:1.28
+          image: busybox:1.34.1
           command: ['sh', '-c', 'rm -f /csi/csi.sock']
           volumeMounts:
             - name: socket-dir
@@ -77,7 +77,7 @@ spec:
         # node-driver-registrar registers your CSI driver with Kubelet so that it knows which Unix
         # domain socket to issue the CSI calls on.
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/example_app.yaml
+++ b/deploy/kubernetes/base/example_app.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox:1.28
+    image: busybox:1.34.1
     command: [ "sleep", "100000000" ]
     volumeMounts:
       - name: lustre-volume

--- a/deploy/kubernetes/base/plugin.yaml
+++ b/deploy/kubernetes/base/plugin.yaml
@@ -28,7 +28,7 @@ spec:
         # already in use (listen unix /csi/csi.sock: bind: address already in use). To combat this, we
         # cleanup the socket, if present, on container init.
         - name: init-socket
-          image: busybox:1.28
+          image: busybox:1.34.1
           command: ['sh', '-c', 'rm -f /csi/csi.sock']
           volumeMounts:
             - name: socket-dir
@@ -76,7 +76,7 @@ spec:
         # node-driver-registrar registers your CSI driver with Kubelet so that it knows which Unix
         # domain socket to issue the CSI calls on.
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/lustre-csi-driver-kind.yaml
+++ b/deploy/kubernetes/lustre-csi-driver-kind.yaml
@@ -76,7 +76,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
         name: csi-node-driver-registrar
         securityContext:
           privileged: true
@@ -90,7 +90,7 @@ spec:
         - sh
         - -c
         - rm -f /csi/csi.sock
-        image: busybox:1.28
+        image: busybox:1.34.1
         name: init-socket
         volumeMounts:
         - mountPath: /csi

--- a/deploy/kubernetes/lustre-csi-driver.yaml
+++ b/deploy/kubernetes/lustre-csi-driver.yaml
@@ -76,7 +76,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3
         name: csi-node-driver-registrar
         securityContext:
           privileged: true
@@ -90,7 +90,7 @@ spec:
         - sh
         - -c
         - rm -f /csi/csi.sock
-        image: busybox:1.28
+        image: busybox:1.34.1
         name: init-socket
         volumeMounts:
         - mountPath: /csi


### PR DESCRIPTION
## Description

Updates the versions of the registrar/busybox images in both the Kustomize base YAMLs and Helm chart templates to their latest stable versions.

## Commits

* Upgrade csi registrar from v2.5.0 -> v2.6.3
* Upgrade busybox from v1.28 -> v1.34.1

## Testing

Tested in a Kubernetes 1.18.20 cluster, connected to a Lustre filesystem via multirail Slingshot 11 interfaces:

Proof of latest image use:
<img width="1701" alt="image" src="https://user-images.githubusercontent.com/26604725/232144261-14ed58b8-ebb0-4dc0-869c-353fcb8bdcdf.png">

Proof of successful `NodePublishVolume` and `NodeUnpublishVolume` (mount/unmount of lustre fs):
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/26604725/232144536-bc062eea-87c4-4ee4-9e1d-f2958cca66c5.png">

Proof of working registrar container:
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/26604725/232144857-7b8ff89d-0381-4a39-b4bb-cbbf4a4d9c1b.png">
