### PR TITLE
Dynamically create an overlay for the image tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ testbin/*
 
 # Go-generated vendor/ directory
 vendor/
+
+# Generated overlay for setting image tag
+deploy/kubernetes/begin/*
+

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,14 @@ docker-build: .version Dockerfile fmt vet
 
 edit-image: VERSION ?= $(shell cat .version)
 edit-image: .version ## Replace plugin.yaml image with name "controller" -> ghcr tagged container reference
-	cd deploy/kubernetes/base && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):$(VERSION)
+	$(KUSTOMIZE_IMAGE_TAG) deploy/kubernetes/begin $(OVERLAY) $(IMAGE_TAG_BASE) $(VERSION)
 
 kind-push: VERSION ?= $(shell cat .version)
 kind-push: .version ## Push image to Kind environment
 	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
 
 deploy_overlay: kustomize edit-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build deploy/kubernetes/$(OVERLAY) | kubectl apply -f -
+	$(KUSTOMIZE) build deploy/kubernetes/begin | kubectl apply -f -
 
 deploy: OVERLAY ?= base
 deploy: deploy_overlay
@@ -100,6 +100,7 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 ## Tool Binaries
+KUSTOMIZE_IMAGE_TAG ?= ./hack/make-kustomization.sh
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 
 ## Tool Versions

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/hack/make-kustomization.sh
+++ b/hack/make-kustomization.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+OVERLAY_DIR=$1
+OVERLAY=$2
+IMAGE_TAG_BASE=$3
+TAG=$4
+
+if [[ ! -d $OVERLAY_DIR ]]
+then
+    mkdir "$OVERLAY_DIR"
+fi
+
+cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
+resources:
+- ../$OVERLAY
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: $IMAGE_TAG_BASE
+  newTag: $TAG
+EOF
+


### PR DESCRIPTION
Avoid editing config/manager/kustomization.yaml to set the image tag.  This causes git to consider the workarea to be dirty, so two consecutive deploys from a workarea that has no other changes will result in the second deploy looking for an image with a "-dirty" tag.

Instead, from the makefile we create a throw-away, and untracked, overlay that will be used to set the image tag.