### PR TITLE
Preserve the service namespace during undeploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ kind-push: .version ## Push image to Kind environment
 	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
 
 deploy_overlay: kustomize edit-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build deploy/kubernetes/begin | kubectl apply -f -
+	./deploy.sh deploy $(KUSTOMIZE) deploy/kubernetes/begin
 
+.PHONY: deploy
 deploy: OVERLAY ?= base
 deploy: deploy_overlay
 
@@ -68,7 +69,7 @@ kind-deploy: OVERLAY=overlays/kind
 kind-deploy: deploy_overlay
 
 undeploy_overlay: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build deploy/kubernetes/$(OVERLAY) | kubectl delete -f -
+	./deploy.sh undeploy $(KUSTOMIZE) deploy/kubernetes/$(OVERLAY)
 
 undeploy: OVERLAY ?= lustre
 undeploy: undeploy_overlay

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Deploy/undeploy controller to the K8s cluster specified in ~/.kube/config.
+
+CMD=$1
+KUSTOMIZE=$2
+OVERLAY_DIR=$3
+
+if [[ $CMD == 'deploy' ]]; then
+    $KUSTOMIZE build $OVERLAY_DIR | kubectl apply -f -
+fi
+
+if [[ $CMD == 'undeploy' ]]; then
+    # Do not touch the namespace resource when deleting this service.
+    $KUSTOMIZE build $OVERLAY_DIR | yq eval 'select(.kind != "Namespace")' |  kubectl delete --ignore-not-found -f -
+fi
+
+exit 0
+


### PR DESCRIPTION
If a pod is on a host that cannot be reached, then any attempt to delete the namespace will hang.  So change this to preserve the namespace and leave that pod for k8s to cleanup when it can.