### PR TITLE
Tolerate the cray.nnf.node.drain taint

### DIFF
--- a/deploy/kubernetes/overlays/kind/manager_tolerations_patch.yaml
+++ b/deploy/kubernetes/overlays/kind/manager_tolerations_patch.yaml
@@ -12,3 +12,5 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+        - key: "cray.nnf.node.drain"
+          operator: "Exists"

--- a/deploy/kubernetes/overlays/rabbit/manager_tolerations_patch.yaml
+++ b/deploy/kubernetes/overlays/rabbit/manager_tolerations_patch.yaml
@@ -12,3 +12,5 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+        - key: "cray.nnf.node.drain"
+          operator: "Exists"


### PR DESCRIPTION
NNF Daemonsets will be drained from nodes via the cray.nnf.node.drain taint. The CSI driver must tolerate that so it can stick around and complete the unmounts that k8s will request.

If CSI were allowed to be drained then nothing would remain to satisfy the k8s unmounts, and k8s would leave the NNF software in Terminating state.