### PR TITLE
Update the README and the helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 - [Features](#features)
 - [Kubernetes Compatibility Matrix](#kubernetes-compatibility-matrix)
 - [Deployment](#deployment)
-  * [Helm](#helm)
-  * [Kubernetes](#kubernetes)
-  * [Kind](#kind)
+  - [Helm](#helm)
+  - [Kubernetes](#kubernetes)
+  - [Kind](#kind)
 - [Usage](#usage)
 
 ## Overview
@@ -22,11 +22,9 @@ frameworks to mount and unmount Lustre filesystems to/from containers in their p
 
 ## Kubernetes Compatibility Matrix
 
-| Lustre CSI Driver / Kubernetes Version | v1.13-1.18 | v1.25 | v1.27 | v1.28-v1.29 | v1.32
-|----------------------------------------|------------|-------|-------|------|-----
-| v0.0.10 | yes | yes | yes
-| v0.1.0  |     |     |     | yes | yes
-
+| Lustre CSI Driver / Kubernetes Version | v1.29-v1.34
+|----------------------------------------|------------
+| v0.1.8+  | yes
 
 ## Deployment
 
@@ -35,39 +33,46 @@ This describes methods of deploying the Lustre CSI driver in various environment
 ### Helm
 
 You can use Helm to manage the lustre CSI driver components:
+
+- To pick a release: `git tag`. Then pick a tag with `git checkout $RELEASE_TAG`
 - To deploy: `cd charts/ && helm install lustre-csi-driver lustre-csi-driver/ --values lustre-csi-driver/values.yaml`
 - To shut down: `helm delete lustre-csi-driver`
 
+For a development build, to install a specific image tag, use the following:
+
+- `helm install lustre-csi-driver lustre-csi-driver/ --values lustre-csi-driver/values.yaml --set deployment.tag=0.0.0.126-4fee`
+
 ### Kubernetes
 
-Deployment uses [Kustomize](https://kustomize.io/) to configure the deployment YAMLs in the [kustomization base](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) 
+Deployment uses [Kustomize](https://kustomize.io/) to configure the deployment YAMLs in the [kustomization base](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays)
 [deploy/kubernetes/base](./deploy/kubernetes/base).
+
 - To deploy using the Makefile: `make deploy`
 - To undeploy using the Makefile: `make undeploy`
 
 To deploy a specific [overlay](./deploy/kubernetes/overlays):
-- `make deploy OVERLAY=overlays/<overlay>`
 
-Otherwise, you can just use the pre-built .yaml files in [deploy/kubernetes](./deploy/kubernetes):
-- `kubectl apply -k 'https://github.com/HewlettPackard/lustre-csi-driver.git/deploy/kubernetes/overlays/kind/?ref=master'`
+- `make deploy OVERLAY=overlays/<overlay>`
 
 ### Kind
 
 This assumes your [Kind](https://kind.sigs.k8s.io/) environment is already set up and ready for a deployment.
 A Kind [kustomization overlay](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays) is defined by the YAMLs in [deploy/kubernetes/overlays/kind](./deploy/kubernetes/overlays/kind).
+
 - To deploy using the Makefile: `make kind-push && make kind-deploy`
 - To undeploy using the Makefile: `make kind-undeploy`
 
 ## Usage
 
-This section provides examples for consuming a Lustre filesystem via a Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) 
-(PV) and [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim) (PVC), 
-and finally an example of using the PVC in a simple application deployed as a Pod. 
+This section provides examples for consuming a Lustre filesystem via a Kubernetes [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+(PV) and [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim) (PVC),
+and finally an example of using the PVC in a simple application deployed as a Pod.
 
 It assumed that a Lustre filesystem is already created, and that the Lustre CSI
 driver is deployed on your Kubernetes cluster wherever the application pods are running (see [Deployment](#deployment) for instructions).
 
 Inspect the `example_*.yaml` Kubernetes resources under [deploy/kubernetes/base](./deploy/kubernetes/base), then:
+
 1. Update [example_pv.yaml](./deploy/kubernetes/base/example_pv.yaml)'s `volumeHandle` value to the NID list of your Lustre filesystem's MGS.
 2. Deploy the PV:  `kubectl apply -f deploy/kubernetes/base/example_pv.yaml`
 3. Deploy the PVC: `kubectl apply -f deploy/kubernetes/base/example_pvc.yaml`
@@ -76,9 +81,13 @@ Inspect the `example_*.yaml` Kubernetes resources under [deploy/kubernetes/base]
 
 ## Steps for Releasing a Version
 
+To perform a release, please use the tools and documentation described in [Releasing NNF Software](https://nearnodeflash.github.io/latest/repo-guides/release-nnf-sw/release-all/#nnf-software-overview). The steps and tools in that guide will ensure that the new release is properly configured to self-identify and to package properly with new releases of the NNF software stack.
+
+The following old steps can be used if this project is ever disassociated from the NNF software stack:
+
 1. Checkout the project at the commit you wish to release
 2. Create a local annotated tag: `git tag -a <tag> -m <message>`
-4. Push this tag to remote: `git push origin <tag>`
+3. Push this tag to remote: `git push origin <tag>`
    - This will trigger a package build with the `<tag>` version
-5. Go to [GitHub releases](https://github.com/HewlettPackard/lustre-csi-driver/releases) and **Draft a New Release**
-6. Use the `tag` corresponding to the release and fill out Title/Features/Bugfixes/etc.
+4. Go to [GitHub releases](https://github.com/HewlettPackard/lustre-csi-driver/releases) and **Draft a New Release**
+5. Use the `tag` corresponding to the release and fill out Title/Features/Bugfixes/etc.

--- a/charts/lustre-csi-driver/Chart.yaml
+++ b/charts/lustre-csi-driver/Chart.yaml
@@ -11,7 +11,7 @@ home: https://github.com/HewlettPackard/lustre-csi-driver
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lustre-csi-driver/templates/driver.yaml
+++ b/charts/lustre-csi-driver/templates/driver.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: lustre-csi-driver
     app.kubernetes.io/name: lustre-csi.hpe.com
     app.kubernetes.io/component: csi-driver
+    app.kubernetes.io/version: {{ .Values.deployment.tag }}
 spec:
   # Indicates this CSI volume driver requires an attachment operation because it implements the CSI
   # ControllerPublishVolume() method, and that the Kubernetes attach/detach controller should call

--- a/charts/lustre-csi-driver/templates/namespace.yaml
+++ b/charts/lustre-csi-driver/templates/namespace.yaml
@@ -3,4 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+  annotations:
+    helm.sh/resource-policy: keep
   name: lustre-csi-system

--- a/charts/lustre-csi-driver/templates/plugin.yaml
+++ b/charts/lustre-csi-driver/templates/plugin.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/part-of: lustre-csi-driver
     app.kubernetes.io/name: lustre-csi-node
     app.kubernetes.io/component: plugin
+    app.kubernetes.io/version: {{ .Values.deployment.tag }}
 spec:
   selector:
     matchLabels:
@@ -22,6 +23,7 @@ spec:
         app.kubernetes.io/part-of: lustre-csi-driver
         app.kubernetes.io/name: lustre-csi-node
         app.kubernetes.io/component: plugin
+        app.kubernetes.io/version: {{ .Values.deployment.tag }}
     spec:
       initContainers:
         # When the CSI Driver hard crashes, it can leave around the socket used for communication between


### PR DESCRIPTION
Update the supported version matrix in the README. Fix some lint issues, and update the instructions to deploy and release.

Update the chart to add the release version as a label on the resources.

Update the namespace spec to add an annotation to prevent helm from deleting the namespace during 'helm uninstall'.