### PR TITLE
Increase git describe --abbrev from 4 to 8

### DIFF
--- a/git-version-gen
+++ b/git-version-gen
@@ -132,8 +132,8 @@ v=
 v_from_git=
 
 if test "`git log -1 --pretty=format:x . 2>&1`" = x \
-    && v=`git describe --abbrev=4 --match="$prefix*" HEAD 2>/dev/null \
-          || git describe --abbrev=4 HEAD 2>/dev/null` \
+    && v=`git describe --abbrev=8 --match="$prefix*" HEAD 2>/dev/null \
+          || git describe --abbrev=8 HEAD 2>/dev/null` \
     && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
     && case $v in
          $prefix[0-9]*) ;;


### PR DESCRIPTION
Prevents version tag mismatch between CI (fresh clone) and local (more objects) when git extends the minimum abbreviation for uniqueness.

With `--abbrev=4`, git will produce different length hashes depending on how many objects are in the local database. CI's fresh clone may produce a 4-char hash while a developer's full clone produces 5+, causing the generated manifest to reference an image tag that doesn't exist in the registry.

With `--abbrev=8`, 4.3 billion possible prefixes makes collisions extremely unlikely in any environment.